### PR TITLE
Fix PID controllers' time delta

### DIFF
--- a/src/auv_pkg/auv_pkg/pitch_pid.py
+++ b/src/auv_pkg/auv_pkg/pitch_pid.py
@@ -82,6 +82,9 @@ class TailPitchRollController(Node):
         self.recovery_factor = 0.0   # Starts at zero, ramps up to 1.0
         self.recovery_rate = 0.05    # Ramp speed for recovery
         self.imu_data_valid = False
+
+        # Timestamp for PID update calculations
+        self.last_update_time = self.get_clock().now()
         
                 # Pitch scaling factors for asymmetric tail response
         self.left_pitch_scale = (90.0 - self.servo_limits[4]["min"])
@@ -128,7 +131,8 @@ class TailPitchRollController(Node):
 
         # Time calculations
         current_time = self.get_clock().now()
-        dt = (current_time.nanoseconds / 1e9)
+        dt = (current_time - self.last_update_time).nanoseconds / 1e9
+        self.last_update_time = current_time
         if dt <= 0:
             return
 

--- a/src/auv_pkg/auv_pkg/roll_pid.py
+++ b/src/auv_pkg/auv_pkg/roll_pid.py
@@ -58,6 +58,9 @@ class WingRollController(Node):
         self.recovery_rate = 0.05   # Speed of ramp-up (tune this value)
         self.imu_data_valid = False
 
+        # Timestamp for PID update calculations
+        self.last_update_time = self.get_clock().now()
+
 
         self.get_logger().info('Wing Roll Controller Node Initialized')
 
@@ -102,7 +105,8 @@ class WingRollController(Node):
 
         # Time calculations
         current_time = self.get_clock().now()
-        dt = (current_time.nanoseconds / 1e9)
+        dt = (current_time - self.last_update_time).nanoseconds / 1e9
+        self.last_update_time = current_time
         if dt <= 0:
             return
 


### PR DESCRIPTION
## Summary
- fix time delta computation in pitch_pid and roll_pid

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ms5837, adafruit_pca9685, ament_copyright, ament_flake8, ament_pep257)*

------
https://chatgpt.com/codex/tasks/task_e_6847c6a35a988332a16e748687fdb5d4