### PR TITLE
Enhance roll PID smoothing and tune constants

### DIFF
--- a/src/auv_pkg/auv_pkg/pitch_pid.py
+++ b/src/auv_pkg/auv_pkg/pitch_pid.py
@@ -16,12 +16,13 @@ class TailPitchRollController(Node):
         # PID Coefficients for Pitch
         self.kp_pitch = 1.5
         self.ki_pitch = 0.03
-        self.kd_pitch = 0.6
+        # Slightly smaller derivative gain to reduce jitter
+        self.kd_pitch = 0.5
 
         # PID Coefficients for Roll
         self.kp_roll = 2.0  # Increased proportional gain for roll
         self.ki_roll = 0.05  # Increased integral gain for stronger adjustments
-        self.kd_roll = 0.8  # Increased derivative gain for faster response
+        self.kd_roll = 0.7  # Slightly reduced derivative gain for smoother roll
 
         # Overcompensation factor for pitch
         self.overcompensation_factor_pitch = 2.0
@@ -43,8 +44,9 @@ class TailPitchRollController(Node):
         self.correction_limit_roll = 25.0  # Increased limit for roll corrections
 
         # Damping factors
-        self.damping_factor_pitch = 0.6
-        self.damping_factor_roll = 0.5  # Reduced damping for quicker response to roll
+        # Increased damping factors help smooth out servo oscillations
+        self.damping_factor_pitch = 0.7
+        self.damping_factor_roll = 0.6
 
         # Previous corrections
         self.previous_correction_pitch = 0.0
@@ -63,7 +65,7 @@ class TailPitchRollController(Node):
         }
 
 
-        # Smoothing factor for IMU noise
+        # Smoothing factor for IMU noise (typical range 0.5-0.9)
         self.alpha = 0.8
 
         # Publisher

--- a/src/auv_pkg/auv_pkg/roll_pid.py
+++ b/src/auv_pkg/auv_pkg/roll_pid.py
@@ -13,7 +13,8 @@ class WingRollController(Node):
         # PID Coefficients for Roll
         self.kp_roll = 2.0  # Proportional gain
         self.ki_roll = 0.05  # Integral gain
-        self.kd_roll = 0.8  # Derivative gain
+        # Slightly smaller derivative gain helps minimize oscillations
+        self.kd_roll = 0.7
 
         # PID state for Roll
         self.integral_error_roll = 0.0
@@ -25,8 +26,8 @@ class WingRollController(Node):
         # Correction clamp limit for roll
         self.correction_limit_roll = 25.0
 
-        # Damping factor for smooth roll corrections
-        self.damping_factor_roll = 0.5
+        # Damping factor for smooth roll corrections (increase for less jitter)
+        self.damping_factor_roll = 0.6
         self.previous_correction_roll = 0.0
 
         # Target and current values
@@ -36,6 +37,9 @@ class WingRollController(Node):
         # Servo limits
         self.min_angle = 90.0
         self.max_angle = 180.0
+
+        # Smoothing factor for IMU noise (tune between 0.5 and 0.9)
+        self.alpha = 0.8
 
         # Activation flag
         self.pid_active = True
@@ -68,7 +72,8 @@ class WingRollController(Node):
         self.target_roll = msg.data
 
     def imu_callback(self, msg):
-        self.current_roll = msg.x  # Assuming roll is in the x field of the IMU message
+        # Exponential smoothing to reduce IMU noise
+        self.current_roll = self.alpha * self.current_roll + (1 - self.alpha) * msg.x
         self.last_imu_time = self.get_clock().now()
         self.imu_data_valid = True
 


### PR DESCRIPTION
## Summary
- smooth roll IMU reading like pitch
- tune derivative and damping constants to reduce jitter
- document the alpha smoothing parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68496acdc5a8833282385473f16757e3