### PR TITLE
Add activation switch for pitch PID controller

### DIFF
--- a/README-EASY.md
+++ b/README-EASY.md
@@ -52,7 +52,7 @@ Below are short explanations and simple visuals for how each node affects the AU
 _____/    \_____     ____/    \____
 ```
 
-This controller reads `imu/euler` and uses PID logic to move the tail servos so the nose pitches up or down. It publishes on `tail_commands`.
+This controller reads `imu/euler` and uses PID logic to move the tail servos so the nose pitches up or down. When active (`tail_pid_active` topic) it publishes on `tail_commands`.
 
 ### `roll_pid` – stabilize the wings
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Tail pitch and roll PID controller.
 * Uses PID coefficients (`kp_pitch`, `ki_pitch`, `kd_pitch`, etc.) and damping to stabilize attitude.【F:src/auv_pkg/auv_pkg/pitch_pid.py†L13-L23】【F:src/auv_pkg/auv_pkg/pitch_pid.py†L37-L46】
 * Servo limits stored in `servo_limits` clamp servo 4 to 30–150° and servo 5 to 60–180°【F:src/auv_pkg/auv_pkg/pitch_pid.py†L61-L65】.
 * Exponential smoothing of IMU input uses factor `alpha` (default `0.8`)【F:src/auv_pkg/auv_pkg/pitch_pid.py†L69-L69】.
-* Publishes commands to `tail_commands` and subscribes to `target_pitch`, `target_roll`, and `imu/euler`【F:src/auv_pkg/auv_pkg/pitch_pid.py†L72-L81】.
+* Publishes commands to `tail_commands` and subscribes to `target_pitch`, `target_roll`, `imu/euler`, and a `tail_pid_active` flag to enable/disable control【F:src/auv_pkg/auv_pkg/pitch_pid.py†L74-L83】.
 
 ### `roll_pid.py`
 Wing roll PID controller.


### PR DESCRIPTION
## Summary
- allow pitch PID controller to be toggled with `tail_pid_active`
- document the new topic in README files

## Testing
- `python3 -m py_compile src/auv_pkg/auv_pkg/pitch_pid.py src/auv_pkg/auv_pkg/roll_pid.py`

------
https://chatgpt.com/codex/tasks/task_e_6853f0a6d30c8332a2996b1cac11dc7d