### PR TITLE
Update servo info in docs

### DIFF
--- a/README-EASY.md
+++ b/README-EASY.md
@@ -117,7 +117,8 @@ The launch file `mobula.launch.xml` starts nodes in this order:
 6. `depth_node`
 7. `acceleration_node`
 
-This ensures sensors are running before control loops and the servo driver are active.
+`servo_driver` is delayed slightly after the IMU initializes. Depth and acceleration
+sensors launch after the control loops.
 
 ---
 Use this quick guide when you need a high-level picture of how the Mobula AUV ROS2 system fits together.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Optional node mapping arm/hand poses to servo commands using OpenCV and MediaPip
 
 
 ### Utility and Test Scripts
-* `servo_test.py` provides a CLI to exercise servos for calibration; angles are clamped to 0–270°.
+* `servo_test.py` provides a CLI to exercise servos for calibration; angles are clamped to 0–180°.
 * `pressure_sensor_test.py` reads the pressure sensor outside of ROS.
 * `fix_imu_node.py` and other backups serve as experimental versions of main nodes.
 

--- a/servo_test.py
+++ b/servo_test.py
@@ -41,7 +41,7 @@ class ServoTestNode:
         print("\n=== SERVO TEST & CALIBRATION TOOL ===")
         print("---------------------------------------")
         print(" Available Commands:")
-        print("  set <servo> <angle>        → Set servo # to angle (clamped 0°–270°)")
+        print("  set <servo> <angle>        → Set servo # to angle (clamped 0°–180°)")
         print("  sweep <servo> <min> <max>  → Sweep servo between min and max angles")
         print("  stop                      → Stop sweeping")
         print("  preset <name>             → Move all servos to preset positions")


### PR DESCRIPTION
## Summary
- clarify servo launch order in quick start guide
- fix servo_test angle range note in docs and script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for ms5837, adafruit_pca9685, ament_*)*

------
https://chatgpt.com/codex/tasks/task_e_6854d9493800833291f94d772feb50f5