### PR TITLE
Fix sea level pressure calc

### DIFF
--- a/src/auv_pkg/auv_pkg/Depth_bu
+++ b/src/auv_pkg/auv_pkg/Depth_bu
@@ -62,11 +62,12 @@ class DepthSensorNode(Node):
             raise RuntimeError("Sensor read failed")
 
         initial_pressure = self.sensor.pressure(ms5837.UNITS_mbar)
-        reference_sea_level_pressure = initial_pressure + (DENSITY_AIR * GRAVITY * KNOWN_TESTING_ALTITUDE)
+        delta_pressure = (DENSITY_AIR * GRAVITY * KNOWN_TESTING_ALTITUDE) / 100
+        reference_sea_level_pressure = initial_pressure + delta_pressure
 
         self.get_logger().info(
             f"✅ Calculated sea-level reference pressure for air mode: {reference_sea_level_pressure:.2f} mbar "
-            f"(initial reading {initial_pressure:.2f} mbar at {KNOWN_TESTING_ALTITUDE} m altitude)"
+            f"(initial {initial_pressure:.2f} mbar, ΔP {delta_pressure:.2f} mbar at {KNOWN_TESTING_ALTITUDE} m)"
         )
 
         return reference_sea_level_pressure

--- a/src/auv_pkg/auv_pkg/depth_node.py
+++ b/src/auv_pkg/auv_pkg/depth_node.py
@@ -65,11 +65,12 @@ class DepthSensorNode(Node):
             raise RuntimeError("Sensor read failed")
 
         initial_pressure = self.sensor.pressure(ms5837.UNITS_mbar)
-        reference_sea_level_pressure = initial_pressure + (DENSITY_AIR * GRAVITY * KNOWN_TESTING_ALTITUDE)
+        delta_pressure = (DENSITY_AIR * GRAVITY * KNOWN_TESTING_ALTITUDE) / 100
+        reference_sea_level_pressure = initial_pressure + delta_pressure
 
         self.get_logger().info(
             f"✅ Calculated sea-level reference pressure for air mode: {reference_sea_level_pressure:.2f} mbar "
-            f"(initial reading {initial_pressure:.2f} mbar at {KNOWN_TESTING_ALTITUDE} m altitude)"
+            f"(initial {initial_pressure:.2f} mbar, ΔP {delta_pressure:.2f} mbar at {KNOWN_TESTING_ALTITUDE} m)"
         )
 
         return reference_sea_level_pressure


### PR DESCRIPTION
## Summary
- tune sea level reference pressure calculation for air mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ms5837')*

------
https://chatgpt.com/codex/tasks/task_e_68561c1eb1048332b6e61010c7e6e137