### PR TITLE
Fix depth deadband size

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Many scripts expose constants or parameters that change the AUV response:
 * **Servo ranges** – update `servo_limits` in `pitch_pid.py` or the default `glide_position` parameter of `servo_driver.py`.
 * **Interpolation rate** – tune `update_rate_hz` and `interpolation_density` for the `servo_interpolation` node.
 * **I2C write frequency** – `servo_driver` writes to the PCA9685 board at `update_rate_hz` (30 Hz by default) but only sends updates when the change exceeds `angle_tolerance_deg`.
-* **Depth deadband** – modify `deadband_threshold` in `depth_node.py` to change how small pressure variations are ignored.
+* **Depth deadband** – default is ±5 cm. Modify `deadband_threshold` in `depth_node.py` to change how small pressure variations are ignored.
 
 Parameter files or launch arguments can override these values to suit specific hardware.
 

--- a/src/auv_pkg/auv_pkg/depth_node.py
+++ b/src/auv_pkg/auv_pkg/depth_node.py
@@ -32,7 +32,7 @@ class DepthSensorNode(Node):
         self.air_buffer = deque(maxlen=5)
 
         # Deadband setting (meters)
-        self.deadband_threshold = 0.005  # ±5 cm
+        self.deadband_threshold = 0.05  # ±5 cm
 
         # Timer for 2 Hz publishing
         self.timer = self.create_timer(0.5, self.publish_depth)


### PR DESCRIPTION
## Summary
- fix the `depth_node` deadband value
- clarify the default deadband in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for hardware libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68561c8c3b308332a0f0d8fa4be3e13d