### PR TITLE
Smooth PID restart

### DIFF
--- a/src/auv_pkg/auv_pkg/pitch_pid.py
+++ b/src/auv_pkg/auv_pkg/pitch_pid.py
@@ -119,7 +119,11 @@ class TailPitchRollController(Node):
         self.imu_data_valid = True
 
     def pid_activation_callback(self, msg):
+        was_active = self.pid_active
         self.pid_active = msg.data
+        if self.pid_active and not was_active:
+            # Reset recovery ramp when PID control is re-enabled
+            self.recovery_factor = 0.0
 
     def update_pid(self):
         if not self.pid_active:

--- a/src/auv_pkg/auv_pkg/roll_pid.py
+++ b/src/auv_pkg/auv_pkg/roll_pid.py
@@ -78,7 +78,11 @@ class WingRollController(Node):
         self.imu_data_valid = True
 
     def pid_activation_callback(self, msg):
+        was_active = self.pid_active
         self.pid_active = msg.data
+        if self.pid_active and not was_active:
+            # Reset recovery ramp when PID control is re-enabled
+            self.recovery_factor = 0.0
 
     def update_pid(self):
         if not self.pid_active:


### PR DESCRIPTION
## Summary
- ramp PID corrections from zero on reactivation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ms5837, adafruit_pca9685, ament_* modules)*

------
https://chatgpt.com/codex/tasks/task_e_6856990920988332983d9b1cb5964f90