### PR TITLE
Reset PID states when controllers activate

### DIFF
--- a/src/auv_pkg/auv_pkg/pitch_pid.py
+++ b/src/auv_pkg/auv_pkg/pitch_pid.py
@@ -124,6 +124,12 @@ class TailPitchRollController(Node):
         if self.pid_active and not was_active:
             # Reset recovery ramp when PID control is re-enabled
             self.recovery_factor = 0.0
+            self.integral_error_pitch = 0.0
+            self.previous_error_pitch = 0.0
+            self.previous_correction_pitch = 0.0
+            self.integral_error_roll = 0.0
+            self.previous_error_roll = 0.0
+            self.previous_correction_roll = 0.0
 
     def update_pid(self):
         if not self.pid_active:

--- a/src/auv_pkg/auv_pkg/roll_pid.py
+++ b/src/auv_pkg/auv_pkg/roll_pid.py
@@ -83,6 +83,9 @@ class WingRollController(Node):
         if self.pid_active and not was_active:
             # Reset recovery ramp when PID control is re-enabled
             self.recovery_factor = 0.0
+            self.integral_error_roll = 0.0
+            self.previous_error_roll = 0.0
+            self.previous_correction_roll = 0.0
 
     def update_pid(self):
         if not self.pid_active:


### PR DESCRIPTION
## Summary
- reset roll PID state when enabling `roll_pid`
- reset both pitch and roll PID states when enabling `pitch_pid`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ms5837, adafruit_pca9685, ament_*)*

------
https://chatgpt.com/codex/tasks/task_e_6856b5b7a7648332bed959ebdf32fc1f