### PR TITLE
Fix easing factor discontinuities

### DIFF
--- a/src/auv_pkg/auv_pkg/servo_interpolation.py
+++ b/src/auv_pkg/auv_pkg/servo_interpolation.py
@@ -119,12 +119,14 @@ class ServoInterpolationNodeV3(Node):
         return steps
 
     def apply_easing_factors(self, t, easing_in_factor, easing_out_factor):
-        if t < easing_in_factor:
-            return t / easing_in_factor if easing_in_factor > 0 else t
-        elif t > 1 - easing_out_factor:
-            return 1 - (1 - t) / easing_out_factor if easing_out_factor > 0 else t
-        else:
-            return t
+        """Smoothly ease progress near the start and end of a segment."""
+        if easing_in_factor > 0 and t < easing_in_factor:
+            scaled = t / easing_in_factor
+            return scaled * scaled * easing_in_factor
+        if easing_out_factor > 0 and t > 1 - easing_out_factor:
+            scaled = (1 - t) / easing_out_factor
+            return 1 - scaled * scaled * easing_out_factor
+        return t
 
     def cubic_ease_in_out(self, t):
         return 4 * t**3 if t < 0.5 else 1 - ((-2 * t + 2) ** 3) / 2


### PR DESCRIPTION
## Summary
- refine easing logic in `servo_interpolation` so the transition is continuous

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ms5837, adafruit_pca9685, ament packages)*

------
https://chatgpt.com/codex/tasks/task_e_6856c5e33cc88332b3ce5f1c856cdc3f