### PR TITLE
Add interrupt interpolation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Lifecycle node controlling the PCA9685 servo board.
 ### `servo_interpolation.py`
 Interpolates complex movements into small servo steps.
 * Parameters `interpolation_density`, `update_rate_hz`, and `cross_fade_factor` control resolution and blending【F:src/auv_pkg/auv_pkg/servo_interpolation.py†L15-L21】.
+* Parameters `interrupt_transition_duration` and `interrupt_transition_easing` tune the blend from current angles to the first step of a new command【F:src/auv_pkg/auv_pkg/servo_interpolation.py†L15-L25】.
 * Generates servo commands at `update_rate_hz` (70 Hz by default). This determines how often new angles are sent to `servo_driver`.
 * Subscribes to `servo_interpolation_commands` and publishes resulting `ServoMovementCommand` messages to `servo_driver_commands`【F:src/auv_pkg/auv_pkg/servo_interpolation.py†L24-L32】.
 * Maintains the last known servo angles so movements can cross‑fade smoothly.


### PR DESCRIPTION
## Summary
- allow configuration of interrupt transition behaviour in `servo_interpolation.py`
- insert a short transition when a new command interrupts a running one
- document new parameters in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ms5837, adafruit_pca9685, ament_*)*

------
https://chatgpt.com/codex/tasks/task_e_685cbef9822c8332be1770bf7a3c0460