### PR TITLE
Detect stagnant IMU data

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Publishes IMU orientation and health. Important parameters and behaviour:
 * Periodically attempts sensor reinitialization if read failures occur.
 * After repeated failures the node performs a minimal initialization
   (accelerometer only) before restarting.
+* If sensor values remain unchanged for `stagnant_timeout_sec` seconds
+  (default `3.0`), the node restarts itself to recover from bus hangs.
 
 ### `servo_driver.py`
 Lifecycle node controlling the PCA9685 servo board.


### PR DESCRIPTION
## Summary
- restart the imu node when sensor values remain unchanged
- document stagnant data restart in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: ms5837, adafruit_pca9685, ament_copyright, ament_flake8, ament_pep257)*

------
https://chatgpt.com/codex/tasks/task_e_685e605e7ae0833283b2b96eb103e632