### PR TITLE
Ensure IMU initialization pauses publishes during feature reconfig

### DIFF
--- a/src/auv_pkg/auv_pkg/imu_node.py
+++ b/src/auv_pkg/auv_pkg/imu_node.py
@@ -197,6 +197,10 @@ class IMUNode(Node):
     def initialize_sensor(self):
         self.get_logger().info("Initializing BNO08X sensor...")
 
+        # Mark the sensor offline while we reconfigure hardware features so the
+        # publish loop pauses and the retry timer can run if anything fails.
+        self.sensor_ready = False
+
         try:
             if self.i2c:
                 self.i2c.deinit()
@@ -220,6 +224,7 @@ class IMUNode(Node):
                 self.last_failure_reason = str(feature_e)
                 self.get_logger().error(
                     "Invoking failure handler: will attempt soft reset before any restart")
+                self.sensor_ready = False
                 self.record_failure_and_check_restart()
                 return
 


### PR DESCRIPTION
## Summary
- set `sensor_ready` false before BNO08X feature configuration so publishing pauses while the IMU is reinitialized
- ensure initialization failures reset `sensor_ready` before invoking the retry logic so the 5s timer can run recovery

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2aaa8f948332b66d6158f99a36fb